### PR TITLE
Calculation, Passive Manipulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .lovelyignore
+.luarc.json

--- a/blindexpander.json
+++ b/blindexpander.json
@@ -5,8 +5,8 @@
     "description": "Library mod to expand Blind functionalities",
     "prefix": "blindexpander",
     "main_file": "blindexpander.lua",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "dependencies": [
-        "Steamodded (>=1.0.0~BETA-1016c)"
+        "Steamodded (>=1.0.0~BETA-1224a)"
     ]
 }

--- a/blindexpander.lua
+++ b/blindexpander.lua
@@ -89,7 +89,7 @@ local function startup()
         local disabled = G.GAME.blind.disabled or passive_data.disabled
         local loc_res = {}
         if obj then
-            loc_res = obj:loc_vars(G.GAME.blind, passive_data)
+            loc_res = obj:loc_vars(G.GAME.blind, passive_data) or {}
         end
         local no_name = loc_res.no_name
         local loc_key = loc_res.key or passive_data.key

--- a/blindexpander.lua
+++ b/blindexpander.lua
@@ -31,8 +31,22 @@ local function startup()
         if not reset then
             self.passives = blind and lobc_deep_copy(blind.passives)
             if self.passives then
+                self.passives_data = {}
+                for _, key in ipairs(self.passives) do
+                    local obj = blindexpander.Passives[key]
+                    local cfg = {}
+                    if obj then
+                        cfg = copy_table(obj.config)
+                        obj:apply(false)
+                    end
+                    self.passives_data[#self.passives_data + 1] = {
+                        disabled = false,
+                        key = key,
+                        config = cfg
+                    }
+                end
                 self.children.alert = UIBox{
-                    definition = create_UIBox_card_alert(), 
+                    definition = create_UIBox_card_alert(),
                     config = {
                         align = "tri",
                         offset = {
@@ -52,6 +66,7 @@ local function startup()
     function Blind.save(self)
         local blindTable = blind_saveref(self)
         blindTable.passives = self.passives
+        blindTable.passives_data = self.passives_data
         blindTable.original_blind = self.original_blind
         return blindTable
     end
@@ -59,33 +74,234 @@ local function startup()
     local blind_loadref = Blind.load
     function Blind.load(self, blindTable)
         self.passives = blindTable.passives
+        self.passives_data = blindTable.passives_data
         self.original_blind = blindTable.original_blind
         blind_loadref(self, blindTable)
     end
-
-    function info_from_passive(passive)
+    function info_from_passive(passive_data)
         local width = 6
         for _, v in ipairs(SMODS.Mods) do
             if v.passive_ui_size and type(v.passive_ui_size) == "function" then
                 width = math.max(width, v.passive_ui_size())
             end
         end
+        local obj = blindexpander.Passives[passive_data.key]
+        local disabled = G.GAME.blind.disabled or passive_data.disabled
+        local loc_res = {}
+        if obj then
+            loc_res = obj:loc_vars(G.GAME.blind, passive_data)
+        end
+        local no_name = loc_res.no_name
+        local loc_key = loc_res.key or passive_data.key
+        local loc_set = loc_res.set or "Passive"
         local desc_nodes = {}
-        localize{type = 'descriptions', key = passive, set = "Passive", nodes = desc_nodes, vars = {}}
+        localize{type = 'descriptions', key = loc_key, set = loc_set, nodes = desc_nodes, vars = loc_res.vars or {}}
         local desc = {}
         for _, v in ipairs(desc_nodes) do
             desc[#desc+1] = {n=G.UIT.R, config={align = "cl"}, nodes=v}
         end
+        local name_nodes = localize{type = 'name', key = loc_key, set = loc_set, name_nodes = {}, vars = loc_res.vars or {}}
+        if disabled then
+            name_nodes[1].nodes[1].nodes[1].config.strikethrough = G.C.RED
+        end
         return 
         {n=G.UIT.R, config={align = "cl", colour = lighten(G.C.GREY, 0.4), r = 0.1, padding = 0.05}, nodes={
-            {n=G.UIT.R, config={align = "cl", padding = 0.05, r = 0.1}, nodes = localize{type = 'name', key = passive, set = "Passive", name_nodes = {}, vars = {}}},
+            (not no_name) and {n=G.UIT.R, config={align = "cl", padding = 0.05, r = 0.1}, nodes = name_nodes} or nil,
             {n=G.UIT.R, config={align = "cl", minw = width, minh = 0.4, r = 0.1, padding = 0.05, colour = desc_nodes.background_colour or G.C.WHITE}, nodes={{n=G.UIT.R, config={align = "cm", padding = 0.03}, nodes=desc}}}
         }}
     end
 
+    function Blind:disable_passive(key)
+        if find_passive(key) then
+            for _, data in ipairs(self.passives_data) do
+                if data.key == key and not data.disabled then
+                    data.disabled = true
+                    local obj = blindexpander.Passives[key]
+                    if obj then
+                        obj:remove(true)
+                    end
+                    G.E_MANAGER:add_event(Event({
+                        trigger = 'immediate',
+                        func = function()
+                        if self.boss and G.GAME.chips - G.GAME.blind.chips >= 0 then
+                            G.STATE = G.STATES.NEW_ROUND
+                            G.STATE_COMPLETE = false
+                        end
+                        return true
+                    end
+                    }))
+                    for _, v in ipairs(G.playing_cards) do
+                        self:debuff_card(v)
+                    end
+                    for _, v in ipairs(G.jokers.cards) do
+                        self:debuff_card(v)
+                    end
+                    if not self.children.alert then
+                        self.children.alert = UIBox{
+                            definition = create_UIBox_card_alert(),
+                            config = {
+                                align = "tri",
+                                offset = {
+                                    x = 0.1, y = 0
+                                },
+                                parent = self
+                            }
+                        }
+                    end
+                    self:wiggle()
+                    break
+                end
+            end
+        end
+    end
+
+    function Blind:enable_passive(key)
+        if find_passive(key) then
+            for _, data in ipairs(self.passives_data) do
+                if data.key == key and data.disabled then
+                    data.disabled = false
+                    local obj = blindexpander.Passives[key]
+                    if obj then
+                        obj:apply(true)
+                    end
+                    G.E_MANAGER:add_event(Event({
+                        trigger = 'immediate',
+                        func = function()
+                        if self.boss and G.GAME.chips - G.GAME.blind.chips >= 0 then
+                            G.STATE = G.STATES.NEW_ROUND
+                            G.STATE_COMPLETE = false
+                        end
+                        return true
+                    end
+                    }))
+                    for _, v in ipairs(G.playing_cards) do
+                        self:debuff_card(v)
+                    end
+                    for _, v in ipairs(G.jokers.cards) do
+                        self:debuff_card(v)
+                    end
+                    if not self.children.alert then
+                       self.children.alert = UIBox{
+                            definition = create_UIBox_card_alert(),
+                            config = {
+                                align = "tri",
+                                offset = {
+                                    x = 0.1, y = 0
+                                },
+                                parent = self
+                            }
+                        }
+                    end
+                    self:wiggle()
+                    break
+                end
+            end
+        end
+    end
+
+    function Blind:add_passive(key)
+        if not find_passive(key) then
+            local obj = blindexpander.Passives[key]
+            local cfg = {}
+            if obj then
+                obj:apply(false)
+                cfg = copy_table(obj.config)
+            end
+            self.passives_data[#self.passives_data + 1] = {
+                disabled = false,
+                key = key,
+                config = cfg
+            }
+            G.E_MANAGER:add_event(Event({
+                trigger = 'immediate',
+                func = function()
+                if self.boss and G.GAME.chips - G.GAME.blind.chips >= 0 then
+                    G.STATE = G.STATES.NEW_ROUND
+                    G.STATE_COMPLETE = false
+                end
+                return true
+            end
+            }))
+            for _, v in ipairs(G.playing_cards) do
+                self:debuff_card(v)
+            end
+            for _, v in ipairs(G.jokers.cards) do
+                self:debuff_card(v)
+            end
+            if not self.children.alert then
+                self.children.alert = UIBox{
+                    definition = create_UIBox_card_alert(),
+                    config = {
+                        align = "tri",
+                        offset = {
+                            x = 0.1, y = 0
+                        },
+                        parent = self
+                    }
+                }
+            end
+            self:wiggle()
+        end
+    end
+
+    function Blind:remove_passive(key)
+        if find_passive(key) then
+            for i, data in ipairs(self.passives_data) do
+                if data.key == key then
+                    local obj = blindexpander.Passives[key]
+                    if obj then
+                        obj:remove(false)
+                    end
+                    table.remove(self.passives_data, i)
+                    G.E_MANAGER:add_event(Event({
+                        trigger = 'immediate',
+                        func = function()
+                        if self.boss and G.GAME.chips - G.GAME.blind.chips >= 0 then
+                            G.STATE = G.STATES.NEW_ROUND
+                            G.STATE_COMPLETE = false
+                        end
+                        return true
+                    end
+                    }))
+                    for _, v in ipairs(G.playing_cards) do
+                        self:debuff_card(v)
+                    end
+                    for _, v in ipairs(G.jokers.cards) do
+                        self:debuff_card(v)
+                    end
+                    if #self.passives_data ~= 0 and not self.children.alert then
+                        self.children.alert = UIBox{
+                            definition = create_UIBox_card_alert(),
+                            config = {
+                                align = "tri",
+                                offset = {
+                                    x = 0.1, y = 0
+                                },
+                                parent = self
+                            }
+                        }
+                    end
+                    self:wiggle()
+                    break
+                end
+            end
+        end
+    end
+
+    function get_actual_original_blind(key)
+        local obj = G.P_BLINDS[key]
+        if obj.precedes_original and not obj.summon then
+            print("WARNING: precedes_original was set, but Blind does not have a summon")
+        end
+        if obj.precedes_original and obj.summon then
+            return get_actual_original_blind(obj.summon)
+        end
+        return key
+    end
+    ---@param blind Blind
     function create_UIBox_blind_passive(blind)
         local passive_lines = {}
-        for _, v in ipairs(blind.passives) do
+        for _, v in ipairs(blind.passives_data) do
             passive_lines[#passive_lines+1] = info_from_passive(v)
         end
         return
@@ -100,7 +316,7 @@ local function startup()
     function Blind.hover(self)
         if not G.CONTROLLER.dragging.target or G.CONTROLLER.using_touch then 
             if not self.hovering and self.states.visible and self.children.animatedSprite.states.visible then
-                if self.passives then
+                if self.passives_data then
                     G.blind_passive = UIBox{
                         definition = create_UIBox_blind_passive(self),
                         config = {
@@ -108,7 +324,7 @@ local function startup()
                             parent = nil,
                             offset = {
                                 x = 0.15,
-                                y = 0.2 + 0.38*#self.passives,
+                                y = 0.2 + 0.38*#self.passives_data,
                             },  
                             type = "cr",
                         }
@@ -136,9 +352,9 @@ local function startup()
     end
 
     function find_passive(key)
-        if G.GAME.blind and G.GAME.blind.passives then
-            for _, v in ipairs(G.GAME.blind.passives) do
-                if v == key then return true end
+        if G.GAME.blind and G.GAME.blind.passives_data then
+            for _, v in ipairs(G.GAME.blind.passives_data) do
+                if v.key == key then return true end
             end
         end
         return false
@@ -213,7 +429,7 @@ local function startup()
                     if obj.defeat and type(obj.defeat) == 'function' then
                         obj:defeat()
                     end
-                    G.GAME.blind.original_blind = G.GAME.blind.original_blind or G.GAME.blind.config.blind.key
+                    G.GAME.blind.original_blind = G.GAME.blind.original_blind or get_actual_original_blind(G.GAME.blind.config.blind.key)
                     G.GAME.blind:set_blind(G.P_BLINDS[G.GAME.blind.config.blind.summon])
                     G.GAME.blind.dollars = G.P_BLINDS[G.GAME.blind.original_blind].dollars
                     G.GAME.blind.boss = G.P_BLINDS[G.GAME.blind.original_blind].boss
@@ -261,6 +477,27 @@ local function startup()
         end
         return score
     end
+
+    local blind_calcref = Blind.calculate
+    function Blind:calculate(context)
+        local blind_eff = blind_calcref(self, context)
+        local final_ret = { blind_eff }
+        if self.passives_data and not self.disabled then
+            for _, data in ipairs(self.passives_data) do
+                local obj = blindexpander.Passives[data.key]
+                if obj and not data.disabled then
+                    final_ret[#final_ret+1] = obj:calculate(self, data, context)
+                end
+            end
+        end
+        if #final_ret == 0 then
+            return nil
+        elseif #final_ret == 1 then
+            return final_ret[1]
+        else
+            return SMODS.merge_defaults(unpack(final_ret))
+        end
+    end
 end
 
 blindexpander = blindexpander or {}
@@ -269,6 +506,62 @@ if not blindexpander.ver or blindexpander.ver < BLINDEXPANDER_VERSION then
     blindexpander.startup = startup
 end
 
+function UIElement:draw_pixellated_strikethough(_type, _parallax, _emboss, _progress)
+    if not self.pixellated_rect or
+        #self.pixellated_rect[_type].vertices < 1 or
+        _parallax ~= self.pixellated_rect.parallax or
+        self.pixellated_rect.w ~= self.VT.w or
+        self.pixellated_rect.h ~= self.VT.h or
+        self.pixellated_rect.sw ~= self.shadow_parrallax.x or
+        self.pixellated_rect.sh ~= self.shadow_parrallax.y or
+        self.pixellated_rect.progress ~= (_progress or 1)
+    then
+        self.pixellated_rect = {
+            w = self.VT.w,
+            h = self.VT.h,
+            sw = self.shadow_parrallax.x,
+            sh = self.shadow_parrallax.y,
+            progress = (_progress or 1),
+            fill = {vertices = {}},
+            shadow = {vertices = {}},
+            line = {vertices = {}},
+            emboss = {vertices = {}},
+            line_emboss = {vertices = {}},
+            parallax = _parallax
+        }
+        local ext_up = self.config.ext_up and self.config.ext_up*G.TILESIZE or 0
+        local totw, toth = self.VT.w*G.TILESIZE, (self.VT.h + math.abs(ext_up)/G.TILESIZE)*G.TILESIZE
+
+        local vertices = {
+            totw,toth/2+ext_up,
+            0, toth/2+ext_up,
+            0, toth/2+ext_up+1,
+            totw,toth/2+ext_up+1
+        }
+        for k, v in ipairs(vertices) do
+            if k%2 == 1 and v > totw*self.pixellated_rect.progress then v = totw*self.pixellated_rect.progress end
+            self.pixellated_rect.fill.vertices[k] = v
+            if k > 4 then
+                self.pixellated_rect.line.vertices[k-4] = v
+                if _emboss then
+                    self.pixellated_rect.line_emboss.vertices[k-4] = v + (k%2 == 0 and -_emboss*self.shadow_parrallax.y or -0.7*_emboss*self.shadow_parrallax.x)
+                end
+            end
+            if k%2 == 0 then
+                self.pixellated_rect.shadow.vertices[k] = v -self.shadow_parrallax.y*_parallax
+                if _emboss then
+                    self.pixellated_rect.emboss.vertices[k] = v + _emboss*G.TILESIZE
+                end
+            else
+                self.pixellated_rect.shadow.vertices[k] = v -self.shadow_parrallax.x*_parallax
+                if _emboss then
+                    self.pixellated_rect.emboss.vertices[k] = v
+                end
+            end
+        end
+    end
+    love.graphics.polygon("fill", self.pixellated_rect.fill.vertices)
+end
 
 local injectItemsref = SMODS.injectItems
 function SMODS.injectItems()

--- a/blindexpander.lua
+++ b/blindexpander.lua
@@ -162,7 +162,7 @@ local function startup()
                     data.disabled = false
                     local obj = blindexpander.Passives[key]
                     if obj then
-                        obj:apply(true)
+                        obj:apply(data, true)
                     end
                     G.E_MANAGER:add_event(Event({
                         trigger = 'immediate',
@@ -180,7 +180,7 @@ local function startup()
                     for _, v in ipairs(G.jokers.cards) do
                         self:debuff_card(v)
                     end
-                    if not self.children.alert then
+                    if not self.children.alert and not self.disabled then
                        self.children.alert = UIBox{
                             definition = create_UIBox_card_alert(),
                             config = {
@@ -204,14 +204,17 @@ local function startup()
             local obj = blindexpander.Passives[key]
             local cfg = {}
             if obj then
-                obj:apply(false)
                 cfg = copy_table(obj.config)
             end
-            self.passives_data[#self.passives_data + 1] = {
+            local data = {
                 disabled = false,
                 key = key,
                 config = cfg
             }
+            if obj then
+                obj:apply(data, false)
+            end
+            self.passives_data[#self.passives_data + 1] = data
             G.E_MANAGER:add_event(Event({
                 trigger = 'immediate',
                 func = function()
@@ -250,7 +253,7 @@ local function startup()
                 if data.key == key then
                     local obj = blindexpander.Passives[key]
                     if obj then
-                        obj:remove(false)
+                        obj:remove(data, false)
                     end
                     table.remove(self.passives_data, i)
                     G.E_MANAGER:add_event(Event({
@@ -365,7 +368,7 @@ local function startup()
         if self.buttons then self.buttons:remove(); self.buttons = nil end
         if self.shop then self.shop:remove(); self.shop = nil end
 
-        if not G.STATE_COMPLETE and not G.GAME.blind.disabled and (G.GAME.blind.config.blind.summon or G.GAME.blind.config.blind.phases or G.GAME.blind.original_blind) then
+        if not G.STATE_COMPLETE and (not G.GAME.blind.disabled or G.GAME.blind.config.blind.summon_while_disabled) and (G.GAME.blind.config.blind.summon or G.GAME.blind.config.blind.phases or G.GAME.blind.original_blind) then
             if G.GAME.blind.original_blind and not G.GAME.blind.config.blind.summon then -- Triggers if blind is not the original blind
                 -- Reset to the original blind's values
                 if G.GAME.blind.original_blind ~= G.GAME.blind.config.blind.key then

--- a/blindexpander.lua
+++ b/blindexpander.lua
@@ -368,7 +368,7 @@ local function startup()
         if self.buttons then self.buttons:remove(); self.buttons = nil end
         if self.shop then self.shop:remove(); self.shop = nil end
 
-        if not G.STATE_COMPLETE and (not G.GAME.blind.disabled or G.GAME.blind.config.blind.summon_while_disabled) and (G.GAME.blind.config.blind.summon or G.GAME.blind.config.blind.phases or G.GAME.blind.original_blind) then
+        if not G.STATE_COMPLETE and (not G.GAME.blind.disabled or (G.GAME.blind.config.blind.summon and G.GAME.blind.config.blind.summon_while_disabled)) and (G.GAME.blind.config.blind.summon or G.GAME.blind.config.blind.phases or G.GAME.blind.original_blind) then
             if G.GAME.blind.original_blind and not G.GAME.blind.config.blind.summon then -- Triggers if blind is not the original blind
                 -- Reset to the original blind's values
                 if G.GAME.blind.original_blind ~= G.GAME.blind.config.blind.key then

--- a/blindexpander.lua
+++ b/blindexpander.lua
@@ -118,7 +118,7 @@ local function startup()
                     data.disabled = true
                     local obj = blindexpander.Passives[key]
                     if obj then
-                        obj:remove(true)
+                        obj:remove(self, data, true)
                     end
                     G.E_MANAGER:add_event(Event({
                         trigger = 'immediate',
@@ -162,7 +162,7 @@ local function startup()
                     data.disabled = false
                     local obj = blindexpander.Passives[key]
                     if obj then
-                        obj:apply(data, true)
+                        obj:apply(self, data, true)
                     end
                     G.E_MANAGER:add_event(Event({
                         trigger = 'immediate',
@@ -212,7 +212,7 @@ local function startup()
                 config = cfg
             }
             if obj then
-                obj:apply(data, false)
+                obj:apply(self, data, false)
             end
             self.passives_data[#self.passives_data + 1] = data
             G.E_MANAGER:add_event(Event({
@@ -253,7 +253,7 @@ local function startup()
                 if data.key == key then
                     local obj = blindexpander.Passives[key]
                     if obj then
-                        obj:remove(data, false)
+                        obj:remove(self, data, false)
                     end
                     table.remove(self.passives_data, i)
                     G.E_MANAGER:add_event(Event({

--- a/lovely.toml
+++ b/lovely.toml
@@ -35,7 +35,7 @@ blindexpander.Passive = SMODS.GameObject:extend({
     class_prefix = "psv",
     calculate = function(self, blind, passive, context) end,
     inject = function(self, i) end,
-    disable = function(self) end,
+    remove = function(self) end,
     apply = function(self, from_disable) end
 })
 '''

--- a/lovely.toml
+++ b/lovely.toml
@@ -1,0 +1,87 @@
+[manifest]
+version = "1.0.0"
+dump_lua = true
+priority = 0
+
+# Make sure that global table exists before SMODS loading
+[[patches]]
+[patches.pattern]
+target = "game.lua"
+pattern = "self.SPEEDFACTOR = 1"
+position = "before"
+payload = '''
+blindexpander = blindexpander or {}
+'''
+match_indent = true
+
+# Make sure that the Passive class exists before mods load
+[[patches]]
+[patches.pattern]
+target = '=[SMODS _ "src/game_object.lua"]'
+pattern = "SMODS.Blinds = {}"
+position = "before"
+payload = '''
+blindexpander.Passives = {}
+
+blindexpander.Passive = SMODS.GameObject:extend({
+    set = "Passive",
+    obj_buffer = {},
+    obj_table = blindexpander.Passives,
+    required_params = {
+        "key",
+    },
+    loc_vars = function(self, blind, passive) end,
+    config = {},
+    class_prefix = "psv",
+    calculate = function(self, blind, passive, context) end,
+    inject = function(self, i) end,
+    disable = function(self) end,
+    apply = function(self, from_disable) end
+})
+'''
+match_indent = true
+
+# Add strikethrough property for text
+[[patches]]
+[patches.pattern]
+target = 'engine/ui.lua'
+match_indent = true
+position = 'before'
+pattern = '''
+--Draw the 'chosen triangle'
+'''
+payload = '''
+if self.config.strikethrough and self.config.strikethrough[4] > 0.01 then 
+    prep_draw(self, 1)
+    love.graphics.scale(1/(G.TILESIZE))
+    love.graphics.setLineWidth(1)
+    love.graphics.setColor(self.config.strikethrough)
+    self:draw_pixellated_strikethough('line', parallax_dist)
+    love.graphics.pop()
+end
+'''
+
+# DynaText compat
+[[patches]]
+[patches.pattern]
+target = 'functions/misc_functions.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+final_line[#final_line].nodes[1] = {n=G.UIT.O, config={
+'''
+payload = '''
+strikethrough = part.control.st and loc_colour(part.control.st),
+'''
+
+[[patches]]
+[patches.pattern]
+target = 'functions/misc_functions.lua'
+match_indent = true
+position = 'after'
+pattern = '''
+font = SMODS.Fonts[part.control.f] or G.FONTS[tonumber(part.control.f)],
+'''
+payload = '''
+strikethrough = part.control.st and loc_colour(part.control.st),
+'''

--- a/lsp_def/blindexpander.lua
+++ b/lsp_def/blindexpander.lua
@@ -19,10 +19,19 @@ function SMODS.current_mod.passive_ui_size() end
 ---@return boolean
 function find_passive(key) end
 
+--- Gets the original Blind's key when a Blind is set. Will recursively check a Blind's summon until the Blind either does not precede the original or does not have a summon.
+---@param key string
+---@return string
+function get_actual_original_blind(key) end
+
+---@type table<string, blindexpander.Passive>
+blindexpander.Passives = {}
+
 ---@class SMODS.GameObject: metatable
 ---@class SMODS.Blind: SMODS.GameObject
----@field passives? table Contains passive keys.
+---@field passives? string[] Contains passive keys.
 ---@field summon? string Key of the Blind to be fought after current Blind ends.
+---@field precedes_original? boolean If true, its summon is considered the original Blind. Will recursively check the Blind's chain of summons.
 ---@field phases? number Amount of times Blind need to be defeated before round ends.
 ---@field phase_refresh? boolean Whether the deck should be refreshed when Blind is defeated.
 ---@field mod_score? fun(self: SMODS.Blind|table, score: number): number Modifies the score. 

--- a/lsp_def/blindexpander.lua
+++ b/lsp_def/blindexpander.lua
@@ -1,9 +1,9 @@
 ---@meta
 
 --- Returns a row node that contains information of a passive.
----@param passive string Key of the passive.
+---@param passive_data PassiveData A table representing a Passive.
 ---@return table
-function info_from_passive(passive) end
+function info_from_passive(passive_data) end
 
 --- Returns a root node that contains the UIBox of all passives.
 ---@param blind table Current blind. (G.GAME.blind)
@@ -14,7 +14,7 @@ function create_UIBox_blind_passive(blind) end
 ---@return number passive_width Width of the passive UIBox, default 6
 function SMODS.current_mod.passive_ui_size() end
 
---- Finds whether a passive is on the current blind or not.
+--- Finds whether or not the current blind has a passive with the given key.
 ---@param key string Key of the passive.
 ---@return boolean
 function find_passive(key) end

--- a/lsp_def/blindexpander.lua
+++ b/lsp_def/blindexpander.lua
@@ -30,6 +30,7 @@ blindexpander.Passives = {}
 ---@class SMODS.GameObject: metatable
 ---@class SMODS.Blind: SMODS.GameObject
 ---@field passives? string[] Contains passive keys.
+---@field summon_while_disabled? boolean If true, this Blind will summon the next Blind, even if this Blind is disabled.
 ---@field summon? string Key of the Blind to be fought after current Blind ends.
 ---@field precedes_original? boolean If true, its summon is considered the original Blind. Will recursively check the Blind's chain of summons.
 ---@field phases? number Amount of times Blind need to be defeated before round ends.

--- a/lsp_def/passive.lua
+++ b/lsp_def/passive.lua
@@ -20,8 +20,8 @@
 ---@field obj_table? table<string, blindexpander.Passive|table> Table of objects registered to this class.
 ---@field loc_vars? fun(self: blindexpander.Passive, blind: Blind, passive: PassiveData): table?.
 ---@field calculate? fun(self: blindexpander.Passive, blind: Blind, passive: PassiveData, context: CalcContext): table? Acts as a usual calculate function.
----@field remove? fun(self: blindexpander.Passive, passive: PassiveData, from_disable: boolean?) Called when this passive is removed or disabled. `from_disable` is true if the passive is being disabled.
----@field apply? fun(self: blindexpander.Passive, passive: PassiveData, from_disable: boolean?) Called when this passive is applied to the Blind or this passive becomes reenabled. `from_disable` is true if the passive is being reenabled.
+---@field remove? fun(self: blindexpander.Passive, blind: Blind, passive: PassiveData, from_disable: boolean?) Called when this passive is removed or disabled. `from_disable` is true if the passive is being disabled.
+---@field apply? fun(self: blindexpander.Passive, blind: Blind, passive: PassiveData, from_disable: boolean?) Called when this passive is applied to the Blind or this passive becomes reenabled. `from_disable` is true if the passive is being reenabled.
 
 ---@overload fun(self: blindexpander.Passive): blindexpander.Passive
 blindexpander.Passive = setmetatable({}, {

--- a/lsp_def/passive.lua
+++ b/lsp_def/passive.lua
@@ -20,8 +20,8 @@
 ---@field obj_table? table<string, blindexpander.Passive|table> Table of objects registered to this class.
 ---@field loc_vars? fun(self: blindexpander.Passive, blind: Blind, passive: PassiveData): table?.
 ---@field calculate? fun(self: blindexpander.Passive, blind: Blind, passive: PassiveData, context: CalcContext): table? Acts as a usual calculate function.
----@field remove? fun(self: blindexpander.Passive, passive: PassiveData, from_disable: boolean?) Called when this passive is removed or disabled.
----@field apply? fun(self: blindexpander.Passive, passive: PassiveData, from_disable: boolean?) Called when this passive is applied to the Blind or this passive becomes undisabled.
+---@field remove? fun(self: blindexpander.Passive, passive: PassiveData, from_disable: boolean?) Called when this passive is removed or disabled. `from_disable` is true if the passive is being disabled.
+---@field apply? fun(self: blindexpander.Passive, passive: PassiveData, from_disable: boolean?) Called when this passive is applied to the Blind or this passive becomes reenabled. `from_disable` is true if the passive is being reenabled.
 
 ---@overload fun(self: blindexpander.Passive): blindexpander.Passive
 blindexpander.Passive = setmetatable({}, {
@@ -32,8 +32,12 @@ blindexpander.Passive = setmetatable({}, {
 
 ---@class Blind
 ---@field passives_data? PassiveData[] Contains tables that store the states of individual passives.
+---@field enable_passive? fun(self: Blind, key: string) Enables the passive with the given key. Does nothing if the blind does not have a passive with the given key.
+---@field disable_passive? fun(self: Blind, key: string) Disables the passive with the given key. Does nothing if the blind does not have a passive with the given key.
+---@field add_passive? fun(self: Blind, key: string) Adds the passive with the given key to the current blind. Does nothing if the blind has a passive with the given key.
+---@field remove_passive? fun(self: Blind, key: string) Removes the passive with the given key from the current blind. Does nothing if the blind does not have a passive with the given key.
 
 ---@class PassiveData
----@field config table
----@field disabled boolean
----@field key string
+---@field config table The internal state of the passive.
+---@field disabled boolean Whether or not this passive is disabled.
+---@field key string The key of the passive.

--- a/lsp_def/passive.lua
+++ b/lsp_def/passive.lua
@@ -1,0 +1,39 @@
+---@meta
+
+---@class blindexpander.Passive: SMODS.GameObject
+---@field super? SMODS.GameObject|table Parent class.
+---@field __call? fun(self: blindexpander.Passive|table, o: blindexpander.Passive|table): nil|table|blindexpander.Passive
+---@field extend? fun(self: blindexpander.Passive|table, o: blindexpander.Passive|table): table Primary method of creating a class.
+---@field check_duplicate_register? fun(self: blindexpander.Passive|table): boolean? Ensures objects already registered will not register.
+---@field check_duplicate_key? fun(self: blindexpander.Passive|table): boolean? Ensures objects with duplicate keys will not register. Checked on `__call` but not `take_ownership`. For take_ownership, the key must exist.
+---@field register? fun(self: blindexpander.Passive|table) Registers the object.
+---@field check_dependencies? fun(self: blindexpander.Passive|table): boolean? Returns `true` if there's no failed dependencies.
+---@field process_loc_text? fun(self: blindexpander.Passive|table) Called during `inject_class`. Handles injecting loc_text.
+---@field send_to_subclasses? fun(self: blindexpander.Passive|table, func: string, ...: any) Starting from this class, recusively searches for functions with the given key on all subordinate classes and run all found functions with the given arguments.
+---@field pre_inject_class? fun(self: blindexpander.Passive|table) Called before `inject_class`. Injects and manages class information before object injection.
+---@field post_inject_class? fun(self: blindexpander.Passive|table) Called after `inject_class`. Injects and manages class information after object injection.
+---@field inject_class? fun(self: blindexpander.Passive|table) Injects all direct instances of class objects by calling `obj:inject` and `obj:process_loc_text`. Also injects anything necessary for the class itself. Only called if class has defined both `obj_table` and `obj_buffer`.
+---@field inject? fun(self: blindexpander.Passive|table, i?: number) Called during `inject_class`. Injects the object into the game.
+---@field take_ownership? fun(self: blindexpander.Passive|table, key: string, obj: blindexpander.Passive|table, silent?: boolean): nil|table|blindexpander.Passive Takes control of vanilla objects. Child class must have get_obj for this to function
+---@field get_obj? fun(self: blindexpander.Passive|table, key: string): blindexpander.Passive|table? Returns an object if one matches the `key`.
+---@field obj_buffer? string[] Array of keys to all objects registered to this class. 
+---@field obj_table? table<string, blindexpander.Passive|table> Table of objects registered to this class.
+---@field loc_vars? fun(self: blindexpander.Passive, blind: Blind, passive: PassiveData): table?.
+---@field calculate? fun(self: blindexpander.Passive, blind: Blind, passive: PassiveData, context: CalcContext): table? Acts as a usual calculate function.
+---@field remove? fun(self: blindexpander.Passive, from_disable) Called when this passive is removed or disabled.
+---@field apply? fun(self: blindexpander.Passive, from_disable: boolean?) Called when this passive is applied to the Blind or this passive becomes undisabled.
+
+---@overload fun(self: blindexpander.Passive): blindexpander.Passive
+blindexpander.Passive = setmetatable({}, {
+	__call = function(self)
+		return self
+	end,
+})
+
+---@class Blind
+---@field passives_data? PassiveData[] Contains tables that store the states of individual passives.
+
+---@class PassiveData
+---@field config table
+---@field disabled boolean
+---@field key string

--- a/lsp_def/passive.lua
+++ b/lsp_def/passive.lua
@@ -20,8 +20,8 @@
 ---@field obj_table? table<string, blindexpander.Passive|table> Table of objects registered to this class.
 ---@field loc_vars? fun(self: blindexpander.Passive, blind: Blind, passive: PassiveData): table?.
 ---@field calculate? fun(self: blindexpander.Passive, blind: Blind, passive: PassiveData, context: CalcContext): table? Acts as a usual calculate function.
----@field remove? fun(self: blindexpander.Passive, from_disable) Called when this passive is removed or disabled.
----@field apply? fun(self: blindexpander.Passive, from_disable: boolean?) Called when this passive is applied to the Blind or this passive becomes undisabled.
+---@field remove? fun(self: blindexpander.Passive, passive: PassiveData, from_disable: boolean?) Called when this passive is removed or disabled.
+---@field apply? fun(self: blindexpander.Passive, passive: PassiveData, from_disable: boolean?) Called when this passive is applied to the Blind or this passive becomes undisabled.
 
 ---@overload fun(self: blindexpander.Passive): blindexpander.Passive
 blindexpander.Passive = setmetatable({}, {


### PR DESCRIPTION
# Summary of Features Added

Passives can now be initialized similarly to an SMODS object. While it is not required (and the usual method of creating passives still works), defining your passive with `blindexpander.Passive` gives the following benefits:

- Passives can store and manipulate their internal state (`config = {}`)
- Passives can interact with the game's context system (`calculate = function(self, blind, passive, context)`, see below for the structure of `passive`)
- Individual Passives can be disabled or reenabled within a Blind (use `Blind:disable_passive(key)` or `Blind:enable_passive(key)`)
- Passives can be removed or added to a Blind while inside a Blind (use `Blind:add_passive(key)` or `Blind:remove_passive(key)`)
- Passives can define a `loc_vars = function(self, blind, passive)` in order to send dynamically updating variables to the passive description

Whenever a Passive is removed or disabled, if its key corresponds to a Passive object, the object's `remove` function is called. Similarly, whenever a Passive is added or reenabled, if its key corresponds to a Passive object, the object's `apply` function is called. You can define `remove = function(self, blind, passive, from_disable)` and `apply = function(self, blind, passive, from_disable)` to implement functionality whenever such events happen.

The system for storing the current Blind passives has changed: `G.GAME.blind.passives_data` is a list of tables. Each table in this list consists of the following entries:

- `disabled`: Whether or not this Passive is disabled
- `key`: The key of this passive
- `config`: A config table to store the Passive's current state. If there is no object in `blindexpander.Passives` that has this passive's key, then this is set to `{}`, otherwise it is set to a deep copy of the object's `config` table.

In addition, there are two new fields that can be defined within `SMODS.Blind` that affect summoned Blinds:

- `precedes_original` (default: `nil`): If set to true, the game will consider the Blind that is summoned by this Blind as the original blind. If this is true but a summon was never defined, then this variable is ignored and a warning message will be printed.
- `summon_while_disabled` (default: `nil`): If set to true, this Blind will summon another Blind with the key provided in `summon` when defeated, regardless of whether or not this Blind is disabled. Does nothing if this Blind does not provide a key in `summon`.

For more information regarding what functions can be defined within a Passive and the types of the parameters that go into these functions, read `lsp_def/passive.lua` and `lsp_def/blindexpander.lua`.