### PR TITLE
Allow passives to show up in info queues

### DIFF
--- a/blindexpander.json
+++ b/blindexpander.json
@@ -5,7 +5,7 @@
     "description": "Library mod to expand Blind functionalities",
     "prefix": "blindexpander",
     "main_file": "blindexpander.lua",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "dependencies": [
         "Steamodded (>=1.0.0~BETA-1224a)"
     ]

--- a/blindexpander.lua
+++ b/blindexpander.lua
@@ -9,7 +9,7 @@
 --- If passive description is too long, changing how it is formatted instead of changing UIBox width is preferred
 
 to_big = to_big or function(x) return x end
-local BLINDEXPANDER_VERSION = 102000
+local BLINDEXPANDER_VERSION = 102010
 
 local function startup()
     if blindexpander.started_up then return end

--- a/blindexpander.lua
+++ b/blindexpander.lua
@@ -214,6 +214,7 @@ local function startup()
             if obj then
                 obj:apply(self, data, false)
             end
+            self.passives_data = self.passives_data or {}
             self.passives_data[#self.passives_data + 1] = data
             G.E_MANAGER:add_event(Event({
                 trigger = 'immediate',
@@ -319,7 +320,7 @@ local function startup()
     function Blind.hover(self)
         if not G.CONTROLLER.dragging.target or G.CONTROLLER.using_touch then 
             if not self.hovering and self.states.visible and self.children.animatedSprite.states.visible then
-                if self.passives_data then
+                if self.passives_data and #self.passives_data > 0 then
                     G.blind_passive = UIBox{
                         definition = create_UIBox_blind_passive(self),
                         config = {

--- a/lovely.toml
+++ b/lovely.toml
@@ -36,9 +36,60 @@ blindexpander.Passive = SMODS.GameObject:extend({
     calculate = function(self, blind, passive, context) end,
     inject = function(self, i) end,
     remove = function(self) end,
-    apply = function(self, from_disable) end
+    apply = function(self, from_disable) end,
+    create_fake_card = function(self)
+        return {
+            config = self.config,
+            disabled = false,
+            key = self.key,
+            fake_card = true
+        }
+    end,
+    generate_ui = function(self, info_queue, card, desc_nodes, specific_vars, full_UI_table)
+        if not card then
+            card = self:create_fake_card()
+        end
+        local target = {
+            type = 'descriptions',
+            key = self.key,
+            set = self.set,
+            nodes = desc_nodes,
+            AUT = full_UI_table,
+            vars =
+                specific_vars or {}
+        }
+        local res = {}
+        if self.loc_vars and type(self.loc_vars) == 'function' then
+            res = self:loc_vars(info_queue, card) or {}
+            target.vars = res.vars or target.vars
+            target.key = res.key or target.key
+            target.set = res.set or target.set
+            target.scale = res.scale
+            target.text_colour = res.text_colour
+        end
+
+        if desc_nodes == full_UI_table.main and not full_UI_table.name then
+            full_UI_table.name = self.set == 'Enhanced' and 'temp_value' or localize { type = 'name', set = target.set, key = res.name_key or target.key, nodes = full_UI_table.name, vars = res.name_vars or target.vars or {} }
+        elseif desc_nodes ~= full_UI_table.main and not desc_nodes.name and self.set ~= 'Enhanced' then
+            desc_nodes.name = localize{type = 'name_text', key = res.name_key or target.key, set = target.set }
+        end
+        if specific_vars and specific_vars.debuffed and not res.replace_debuff then
+            target = { type = 'other', key = 'debuffed_' ..
+            (specific_vars.playing_card and 'playing_card' or 'default'), nodes = desc_nodes, AUT = full_UI_table, }
+        end
+        if res.main_start then
+            desc_nodes[#desc_nodes + 1] = res.main_start
+        end
+
+        localize(target)
+        if res.main_end then
+            desc_nodes[#desc_nodes + 1] = res.main_end
+        end
+        desc_nodes.background_colour = res.background_colour
+    end
 })
 '''
+
 match_indent = true
 
 # Add strikethrough property for text

--- a/lovely.toml
+++ b/lovely.toml
@@ -60,7 +60,7 @@ blindexpander.Passive = SMODS.GameObject:extend({
         }
         local res = {}
         if self.loc_vars and type(self.loc_vars) == 'function' then
-            res = self:loc_vars(info_queue, card) or {}
+            res = self:loc_vars(nil, card) or {}
             target.vars = res.vars or target.vars
             target.key = res.key or target.key
             target.set = res.set or target.set


### PR DESCRIPTION
also fixed some issues regarding passive manipulation

- fixed crash where adding a passive to a blind that didnt initially have one would crash
- fixed issue where a blind with an empty passive table would have some wonky ui when hovered over